### PR TITLE
Update Dockerfile

### DIFF
--- a/phoenix/Dockerfile
+++ b/phoenix/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch AS javabuild
+FROM debian:bullseye AS javabuild
 
 RUN apt-get update && apt-get install -y \
 	openjdk-8-jdk \


### PR DESCRIPTION
Updating Dockerfile to to use Debian Bullseye as stretch no longer can be found during docker-compose